### PR TITLE
Simplify and parse math more like code spans

### DIFF
--- a/specs/math.txt
+++ b/specs/math.txt
@@ -2,7 +2,7 @@ Run this with `cargo run -- -M -s specs/math.txt`.
 
 Mathematical expressions extension. Syntax based on
 <https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/math.md>
-with slight modifications and excluding the handling for balanced curly braces.
+excluding the handling for balanced curly braces.
 
 Inline mode mathematical expressions:
 
@@ -28,23 +28,36 @@ $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \
 <p><span class="math display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)</span></p>
 ````````````````````````````````
 
-Math expressions pass their content through as-is, ignoring any other Markdown constructs:
-
-```````````````````````````````` example
-$a<b>c$
-
-$$a*b*c$$
-.
-<p><span class="math inline">a&lt;b&gt;c</span></p>
-<p><span class="math display">a*b*c</span></p>
-````````````````````````````````
-
-Inline math expressions cannot be empty.
+Inline math expressions cannot be empty, but display mode expressions can.
 
 ```````````````````````````````` example
 Oops empty $$ expression.
+
+$$$$
 .
 <p>Oops empty $$ expression.</p>
+<p><span class="math display"></span></p>
+````````````````````````````````
+
+Math expressions pass their content through as-is, ignoring any other inline
+Markdown constructs:
+
+```````````````````````````````` example
+$a<b>c</b>$
+
+$${a*b*c} _c_ d$$
+
+$not `code`$
+
+$![not an](/image)$
+
+$<https://not.a.link/>$
+.
+<p><span class="math inline">a&lt;b&gt;c&lt;/b&gt;</span></p>
+<p><span class="math display">{a*b*c} _c_ d</span></p>
+<p><span class="math inline">not `code`</span></p>
+<p><span class="math inline">![not an](/image)</span></p>
+<p><span class="math inline">&lt;https://not.a.link/&gt;</span></p>
 ````````````````````````````````
 
 Sole `$` characters without a matching pair in the same block element
@@ -73,6 +86,19 @@ $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
 <p><span class="math display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
 \left( \sum_{k=1}^n b_k^2 \right)</span></p>
 ````````````````````````````````
+
+Markdown hard breaks are also not recognized inside math expressions:
+
+```````````````````````````````` example
+$not a\
+hard break  
+either$
+.
+<p><span class="math inline">not a\
+hard break  
+either</span></p>
+````````````````````````````````
+
 
 `$` character can be escaped with backslash in mathematical expressions:
 
@@ -118,6 +144,28 @@ Inline math expressions do not need to be surrounded with whitespace:
 these are math texts: foo$y=x$bar and $y=x$bar and foo$y=x$ bar
 .
 <p>these are math texts: foo<span class="math inline">y=x</span>bar and <span class="math inline">y=x</span>bar and foo<span class="math inline">y=x</span> bar</p>
+````````````````````````````````
+
+Inline math expressions can be surrounded by punctuation:
+
+```````````````````````````````` example
+math texts: $x=y$! and $x=y$? and $x=y$: and $x=y$. and $x=y$"
+
+also math texts: !$x=y$! and ?$x=y$? and :$x=y$: and .$x=y$. and "$x=y$"
+
+braces: ($x=y$) [$x=y$] {$x=y$}
+.
+<p>math texts: <span class="math inline">x=y</span>! and <span class="math inline">x=y</span>? and <span class="math inline">x=y</span>: and <span class="math inline">x=y</span>. and <span class="math inline">x=y</span>&quot;</p>
+<p>also math texts: !<span class="math inline">x=y</span>! and ?<span class="math inline">x=y</span>? and :<span class="math inline">x=y</span>: and .<span class="math inline">x=y</span>. and &quot;<span class="math inline">x=y</span>&quot;</p>
+<p>braces: (<span class="math inline">x=y</span>) [<span class="math inline">x=y</span>] {<span class="math inline">x=y</span>}</p>
+````````````````````````````````
+
+Math expression as only item on a line:
+
+```````````````````````````````` example
+$x=y$
+.
+<p><span class="math inline">x=y</span></p>
 ````````````````````````````````
 
 Math expressions can be immediately followed by other math expressions:

--- a/specs/math.txt
+++ b/specs/math.txt
@@ -227,3 +227,25 @@ $$ x + y
 <p>z $$</p>
 </blockquote>
 ````````````````````````````````
+
+This also means that math expressions cannot contain empty lines, since they
+start a new paragraph:
+
+```````````````````````````````` example
+$not
+
+math$
+
+$$
+not
+
+math
+$$
+.
+<p>$not</p>
+<p>math$</p>
+<p>$$
+not</p>
+<p>math
+$$</p>
+````````````````````````````````

--- a/specs/math.txt
+++ b/specs/math.txt
@@ -1,23 +1,23 @@
 Run this with `cargo run -- -M -s specs/math.txt`.
 
-Mathematical expressions extension.
-See the following link to know the syntax.
-https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions
+Mathematical expressions extension. Syntax based on
+<https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/math.md>
+with slight modifications and excluding the handling for balanced curly braces.
 
-Inline-level mathematical expressions:
+Inline mode mathematical expressions:
 
 ```````````````````````````````` example
-This sentence uses `$` delimiters to show math inline:  $\sqrt{3x-1}+(1+x)^2$
+This sentence uses `$` delimiters to show math inline: $\sqrt{3x-1}+(1+x)^2$
 $\sum_{k=1}^n a_k b_k$: Mathematical expression at head of line
 
 `\` may follow just after the first `$`: $\{1, 2, 3\}$
 .
-<p>This sentence uses <code>$</code> delimiters to show math inline:  <span class="math inline">\sqrt{3x-1}+(1+x)^2</span>
+<p>This sentence uses <code>$</code> delimiters to show math inline: <span class="math inline">\sqrt{3x-1}+(1+x)^2</span>
 <span class="math inline">\sum_{k=1}^n a_k b_k</span>: Mathematical expression at head of line</p>
-<p><code>\</code> may follow just after the first <code>$</code>:  <span class="math inline">\{1, 2, 3\}</span>
+<p><code>\</code> may follow just after the first <code>$</code>: <span class="math inline">\{1, 2, 3\}</span>
 ````````````````````````````````
 
-Block-level mathematical expressions:
+Display mode mathematical expressions:
 
 ```````````````````````````````` example
 **The Cauchy-Schwarz Inequality**
@@ -25,42 +25,53 @@ Block-level mathematical expressions:
 $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)$$
 .
 <p><strong>The Cauchy-Schwarz Inequality</strong></p>
-<div class="math block">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)</div>
+<p><span class="math display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)</span></p>
 ````````````````````````````````
 
-Empty expressions are edge cases that are not parsed as mathematical expressions:
+Math expressions pass their content through as-is, ignoring any other Markdown constructs:
+
+```````````````````````````````` example
+$a<b>c$
+
+$$a*b*c$$
+.
+<p><span class="math inline">a&lt;b&gt;c</span></p>
+<p><span class="math display">a*b*c</span></p>
+````````````````````````````````
+
+Inline math expressions cannot be empty.
 
 ```````````````````````````````` example
 Oops empty $$ expression.
-
-$$$$
-
-This is also empty: $``$
 .
 <p>Oops empty $$ expression.</p>
-<p>$$$$</p>
-<p>This is also empty: $``$</p>
 ````````````````````````````````
 
-Sole `$` character is handled as normal text. And Inline-level mathematical expressions cannot continue across newlines:
+Sole `$` characters without a matching pair in the same block element
+are handled as normal text.
 
 ```````````````````````````````` example
-Hello $ world.
+Hello $world.
 
-Dollar at end of line: $
+Dollar at end of line$
 .
-<p>Hello $ world.</p>
-<p>Dollar at end of line: $</p>
+<p>Hello $world.</p>
+<p>Dollar at end of line$</p>
 ````````````````````````````````
 
-Block-level mathematical expressions can continue across multiple lines:
+Mathematical expressions can continue across multiple lines:
 
 ```````````````````````````````` example
+$5x + 2 =
+17$
+
 $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
 \left( \sum_{k=1}^n b_k^2 \right)$$
 .
-<div class="math block">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
-\left( \sum_{k=1}^n b_k^2 \right)</div>
+<p><span class="math inline">5x + 2 =
+17</span></p>
+<p><span class="math display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
+\left( \sum_{k=1}^n b_k^2 \right)</span></p>
 ````````````````````````````````
 
 `$` character can be escaped with backslash in mathematical expressions:
@@ -71,57 +82,97 @@ $\$$
 $$y = \$ x$$
 .
 <p><span class="math inline">\$</span></p>
-<div class="math block">y = \$ x</div>
+<p><span class="math display">y = \$ x</span></p>
 ````````````````````````````````
 
-Inline math text with backticks ``$`...`$``:
+Inline mode math expressions cannot contain unescaped `$` characters, but
+display mode expressions can, though not two in a row:
 
 ```````````````````````````````` example
-this is math inline $`y=x`$ test.
-dollar can be contained: $`foo$bar`$
+$x $ x$
+
+$$ $ $$
+
+$$ $$ $$
 .
-<p>this is math inline <span class="math inline">y=x</span> test.
-dollar can be contained: <span class="math inline">foo$bar</span></p>
+<p>$x $ x$</p>
+<p><span class="math display"> $ </span></p>
+<p><span class="math display"> </span> $$</p>
 ````````````````````````````````
 
-Math expression without backtick cannot start/end with spaces but Math expression with backtick can:
+Inline math expressions cannot start or end with whitespace, including newlines:
 
 ```````````````````````````````` example
-these are not math texts: $ y=x$ and $y=x $ and $ y=x $
-but these are math texts: $` y=x`$ and $`y=x `$ and $` y=x `$
+these are not math texts: $ y=x$, $y=x $, $
+y=x$ and $y=x
+$
 .
-<p>these are not math texts: $ y=x$ and $y=x $ and $ y=x $
-but these are math texts: <span class="math inline"> y=x</span> and <span class="math inline">y=x </span> and <span class="math inline"> y=x </span></p>
+<p>these are not math texts: $ y=x$, $y=x $, $
+y=x$ and $y=x
+$</p>
 ````````````````````````````````
 
-Math expression without backtick surrounded with whitespaces:
+Inline math expressions do not need to be surrounded with whitespace:
 
 ```````````````````````````````` example
-these are not math texts: foo$y=x$bar and $y=x$bar and foo$y=x$ bar
-but these are math texts: foo$`y=x`$bar and $`y=x`$bar and foo$`y=x`$ bar
+these are math texts: foo$y=x$bar and $y=x$bar and foo$y=x$ bar
 .
-<p>these are not math texts: foo$y=x$bar and $y=x$bar and foo$y=x$ bar
-but these are math texts: foo<span class="math inline">y=x</span>bar and <span class="math inline">y=x</span>bar and foo<span class="math inline">y=x</span> bar</p>
+<p>these are math texts: foo<span class="math inline">y=x</span>bar and <span class="math inline">y=x</span>bar and foo<span class="math inline">y=x</span> bar</p>
 ````````````````````````````````
 
-Math expression without backtick can be end with punctuation but cannot start with:
+Math expressions can be immediately followed by other math expressions:
 
 ```````````````````````````````` example
-math texts: $x=y$! and $x=y$? and $x=y$: and $x=y$.
-not math texts: !$x=y$! and ?x=y$? and :$x=y$: and .$x=y$.
-backticks doesn't have the edge case: !$`x=y`$! and ?`x=y`$? and :$`x=y`$: and .$`x=y`$.
+$a$$b$
+
+$a$$$b$$
+
+$$a$$$b$
+
+$$a$$$$b$$
 .
-<p>math texts: <span class="math inline">x=y</span>! and <span class="math inline">x=y</span>? and <span class="math inline">x=y</span>: and <span class="math inline">x=y</span>.
-not math texts: !$x=y$! and ?x=y$? and :$x=y$: and .$x=y$.
-backticks doesn't have the edge case: !<span class="math inline">x=y</span>! and ?<code>x=y</code>$? and :<span class="math inline">x=y</span>: and .<span class="math inline">x=y</span>.</p>
+<p><span class="math inline">a</span><span class="math inline">b</span></p>
+<p><span class="math inline">a</span><span class="math display">b</span></p>
+<p><span class="math display">a</span><span class="math inline">b</span></p>
+<p><span class="math display">a</span><span class="math display">b</span></p>
 ````````````````````````````````
 
-Math expression at start and end of lines:
+Both inline and display mode math expressions are inline elements with the same
+precedence as code spans. The leftmost valid element takes priority:
 
 ```````````````````````````````` example
-$x=y$
-$`x=y`$
+$Inline `first$ then` code
+
+`Code $first` then$ inline
+
+$$ Display `first $$ then` code
+
+`Code $$ first` then $$ display
 .
-<p><span class="math inline">x=y</span>
-<span class="math inline">x=y</span></p>
+<p><span class="math inline">Inline `first</span> then` code</p>
+<p><code>Code $first</code> then$ inline</p>
+<p><span class="math display"> Display `first </span> then` code</p>
+<p><code>Code $$ first</code> then $$ display</p>
+````````````````````````````````
+
+Indicators of block structure take precedence over math expressions:
+
+```````````````````````````````` example
+$x + y - z$
+
+$x + y
+- z$
+
+$$ x + y
+> z $$
+.
+<p><span class="math inline">x + y - z</span></p>
+<p>$x + y</p>
+<ul>
+<li>z$</li>
+</ul>
+<p>$$ x + y</p>
+<blockquote>
+<p>z $$</p>
+</blockquote>
 ````````````````````````````````

--- a/specs/math.txt
+++ b/specs/math.txt
@@ -52,12 +52,15 @@ $not `code`$
 $![not an](/image)$
 
 $<https://not.a.link/>$
+
+$&alpha;$
 .
 <p><span class="math inline">a&lt;b&gt;c&lt;/b&gt;</span></p>
 <p><span class="math display">{a*b*c} _c_ d</span></p>
 <p><span class="math inline">not `code`</span></p>
 <p><span class="math inline">![not an](/image)</span></p>
 <p><span class="math inline">&lt;https://not.a.link/&gt;</span></p>
+<p><span class="math inline">&amp;alpha;</span></p>
 ````````````````````````````````
 
 Sole `$` characters without a matching pair in the same block element

--- a/src/html.rs
+++ b/src/html.rs
@@ -26,7 +26,7 @@ use std::io::{self, Write};
 use crate::escape::{escape_href, escape_html, StrWrite, WriteWrapper};
 use crate::strings::CowStr;
 use crate::Event::*;
-use crate::{Alignment, CodeBlockKind, Event, LinkType, MathDisplay, Tag, TagEnd};
+use crate::{Alignment, CodeBlockKind, Event, LinkType, MathMode, Tag, TagEnd};
 
 enum TableState {
     Head,
@@ -138,15 +138,15 @@ where
                 TaskListMarker(false) => {
                     self.write("<input disabled=\"\" type=\"checkbox\"/>\n")?;
                 }
-                Math(MathDisplay::Inline, text) => {
+                Math(MathMode::Inline, text) => {
                     self.write("<span class=\"math inline\">")?;
                     escape_html(&mut self.writer, &text)?;
                     self.write("</span>")?;
                 }
-                Math(MathDisplay::Block, text) => {
-                    self.write("<div class=\"math block\">")?;
+                Math(MathMode::Display, text) => {
+                    self.write("<span class=\"math display\">")?;
                     escape_html(&mut self.writer, &text)?;
-                    self.write("</div>\n")?;
+                    self.write("</span>")?;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,7 @@ pub enum Event<'a> {
     /// A task list marker, rendered as a checkbox in HTML. Contains a true when it is checked.
     TaskListMarker(bool),
     /// A mathematical expression wrapped by a pair of one or two `$` characters.
-    Math(MathDisplay, CowStr<'a>),
+    Math(MathMode, CowStr<'a>),
 }
 
 /// Table column text alignment.
@@ -361,14 +361,14 @@ pub enum Alignment {
     Right,
 }
 
-/// Display kind of mathematical expression.
+/// Math expression mode.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum MathDisplay {
-    /// Inline-level mathematical expression like `$x^2$`.
+pub enum MathMode {
+    /// Inline mode mathematical expression like `$x^2$`.
     Inline,
-    /// Block-level mathematical expression like `$$y = x^2$$`.
-    Block,
+    /// Display mode mathematical expression like `$$y = x^2$$`.
+    Display,
 }
 
 bitflags::bitflags! {
@@ -434,10 +434,7 @@ bitflags::bitflags! {
         /// literal text [^4]. In old syntax, it creates a dangling link.
         /// ```
         const ENABLE_OLD_FOOTNOTES = (1 << 9) | (1 << 2);
-        /// Extension to parse mathematical expressions wrapped by `$`.
-        ///
-        /// See the following document to know the syntax.
-        /// https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions
+        /// Extension to parse mathematical expressions wrapped by `$` or `$$`.
         const ENABLE_MATH = 1 << 10;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,10 @@ pub enum Event<'a> {
     /// A task list marker, rendered as a checkbox in HTML. Contains a true when it is checked.
     TaskListMarker(bool),
     /// A mathematical expression wrapped by a pair of one or two `$` characters.
-    Math(MathMode, CowStr<'a>),
+    Math(
+        MathMode,
+        #[cfg_attr(feature = "serde", serde(borrow))] CowStr<'a>,
+    ),
 }
 
 /// Table column text alignment.

--- a/tests/suite/math.rs
+++ b/tests/suite/math.rs
@@ -55,12 +55,15 @@ $not `code`$
 $![not an](/image)$
 
 $<https://not.a.link/>$
+
+$&alpha;$
 "##;
     let expected = r##"<p><span class="math inline">a&lt;b&gt;c&lt;/b&gt;</span></p>
 <p><span class="math display">{a*b*c} _c_ d</span></p>
 <p><span class="math inline">not `code`</span></p>
 <p><span class="math inline">![not an](/image)</span></p>
 <p><span class="math inline">&lt;https://not.a.link/&gt;</span></p>
+<p><span class="math inline">&amp;alpha;</span></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);

--- a/tests/suite/math.rs
+++ b/tests/suite/math.rs
@@ -253,3 +253,26 @@ $$ x + y
 
     test_markdown_html(original, expected, false, false, false);
 }
+
+#[test]
+fn math_test_17() {
+    let original = r##"$not
+
+math$
+
+$$
+not
+
+math
+$$
+"##;
+    let expected = r##"<p>$not</p>
+<p>math$</p>
+<p>$$
+not</p>
+<p>math
+$$</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}

--- a/tests/suite/math.rs
+++ b/tests/suite/math.rs
@@ -5,14 +5,14 @@ use super::test_markdown_html;
 
 #[test]
 fn math_test_1() {
-    let original = r##"This sentence uses `$` delimiters to show math inline:  $\sqrt{3x-1}+(1+x)^2$
+    let original = r##"This sentence uses `$` delimiters to show math inline: $\sqrt{3x-1}+(1+x)^2$
 $\sum_{k=1}^n a_k b_k$: Mathematical expression at head of line
 
 `\` may follow just after the first `$`: $\{1, 2, 3\}$
 "##;
-    let expected = r##"<p>This sentence uses <code>$</code> delimiters to show math inline:  <span class="math inline">\sqrt{3x-1}+(1+x)^2</span>
+    let expected = r##"<p>This sentence uses <code>$</code> delimiters to show math inline: <span class="math inline">\sqrt{3x-1}+(1+x)^2</span>
 <span class="math inline">\sum_{k=1}^n a_k b_k</span>: Mathematical expression at head of line</p>
-<p><code>\</code> may follow just after the first <code>$</code>:  <span class="math inline">\{1, 2, 3\}</span>
+<p><code>\</code> may follow just after the first <code>$</code>: <span class="math inline">\{1, 2, 3\}</span>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -25,7 +25,7 @@ fn math_test_2() {
 $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)$$
 "##;
     let expected = r##"<p><strong>The Cauchy-Schwarz Inequality</strong></p>
-<div class="math block">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)</div>
+<p><span class="math display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)</span></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -33,15 +33,12 @@ $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \
 
 #[test]
 fn math_test_3() {
-    let original = r##"Oops empty $$ expression.
+    let original = r##"$a<b>c$
 
-$$$$
-
-This is also empty: $``$
+$$a*b*c$$
 "##;
-    let expected = r##"<p>Oops empty $$ expression.</p>
-<p>$$$$</p>
-<p>This is also empty: $``$</p>
+    let expected = r##"<p><span class="math inline">a&lt;b&gt;c</span></p>
+<p><span class="math display">a*b*c</span></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -49,12 +46,9 @@ This is also empty: $``$
 
 #[test]
 fn math_test_4() {
-    let original = r##"Hello $ world.
-
-Dollar at end of line: $
+    let original = r##"Oops empty $$ expression.
 "##;
-    let expected = r##"<p>Hello $ world.</p>
-<p>Dollar at end of line: $</p>
+    let expected = r##"<p>Oops empty $$ expression.</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -62,11 +56,12 @@ Dollar at end of line: $
 
 #[test]
 fn math_test_5() {
-    let original = r##"$$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
-\left( \sum_{k=1}^n b_k^2 \right)$$
+    let original = r##"Hello $world.
+
+Dollar at end of line$
 "##;
-    let expected = r##"<div class="math block">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
-\left( \sum_{k=1}^n b_k^2 \right)</div>
+    let expected = r##"<p>Hello $world.</p>
+<p>Dollar at end of line$</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -74,12 +69,16 @@ fn math_test_5() {
 
 #[test]
 fn math_test_6() {
-    let original = r##"$\$$
+    let original = r##"$5x + 2 =
+17$
 
-$$y = \$ x$$
+$$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
+\left( \sum_{k=1}^n b_k^2 \right)$$
 "##;
-    let expected = r##"<p><span class="math inline">\$</span></p>
-<div class="math block">y = \$ x</div>
+    let expected = r##"<p><span class="math inline">5x + 2 =
+17</span></p>
+<p><span class="math display">\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
+\left( \sum_{k=1}^n b_k^2 \right)</span></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -87,11 +86,12 @@ $$y = \$ x$$
 
 #[test]
 fn math_test_7() {
-    let original = r##"this is math inline $`y=x`$ test.
-dollar can be contained: $`foo$bar`$
+    let original = r##"$\$$
+
+$$y = \$ x$$
 "##;
-    let expected = r##"<p>this is math inline <span class="math inline">y=x</span> test.
-dollar can be contained: <span class="math inline">foo$bar</span></p>
+    let expected = r##"<p><span class="math inline">\$</span></p>
+<p><span class="math display">y = \$ x</span></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -99,11 +99,15 @@ dollar can be contained: <span class="math inline">foo$bar</span></p>
 
 #[test]
 fn math_test_8() {
-    let original = r##"these are not math texts: $ y=x$ and $y=x $ and $ y=x $
-but these are math texts: $` y=x`$ and $`y=x `$ and $` y=x `$
+    let original = r##"$x $ x$
+
+$$ $ $$
+
+$$ $$ $$
 "##;
-    let expected = r##"<p>these are not math texts: $ y=x$ and $y=x $ and $ y=x $
-but these are math texts: <span class="math inline"> y=x</span> and <span class="math inline">y=x </span> and <span class="math inline"> y=x </span></p>
+    let expected = r##"<p>$x $ x$</p>
+<p><span class="math display"> $ </span></p>
+<p><span class="math display"> </span> $$</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -111,11 +115,13 @@ but these are math texts: <span class="math inline"> y=x</span> and <span class=
 
 #[test]
 fn math_test_9() {
-    let original = r##"these are not math texts: foo$y=x$bar and $y=x$bar and foo$y=x$ bar
-but these are math texts: foo$`y=x`$bar and $`y=x`$bar and foo$`y=x`$ bar
+    let original = r##"these are not math texts: $ y=x$, $y=x $, $
+y=x$ and $y=x
+$
 "##;
-    let expected = r##"<p>these are not math texts: foo$y=x$bar and $y=x$bar and foo$y=x$ bar
-but these are math texts: foo<span class="math inline">y=x</span>bar and <span class="math inline">y=x</span>bar and foo<span class="math inline">y=x</span> bar</p>
+    let expected = r##"<p>these are not math texts: $ y=x$, $y=x $, $
+y=x$ and $y=x
+$</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -123,13 +129,9 @@ but these are math texts: foo<span class="math inline">y=x</span>bar and <span c
 
 #[test]
 fn math_test_10() {
-    let original = r##"math texts: $x=y$! and $x=y$? and $x=y$: and $x=y$.
-not math texts: !$x=y$! and ?x=y$? and :$x=y$: and .$x=y$.
-backticks doesn't have the edge case: !$`x=y`$! and ?`x=y`$? and :$`x=y`$: and .$`x=y`$.
+    let original = r##"these are math texts: foo$y=x$bar and $y=x$bar and foo$y=x$ bar
 "##;
-    let expected = r##"<p>math texts: <span class="math inline">x=y</span>! and <span class="math inline">x=y</span>? and <span class="math inline">x=y</span>: and <span class="math inline">x=y</span>.
-not math texts: !$x=y$! and ?x=y$? and :$x=y$: and .$x=y$.
-backticks doesn't have the edge case: !<span class="math inline">x=y</span>! and ?<code>x=y</code>$? and :<span class="math inline">x=y</span>: and .<span class="math inline">x=y</span>.</p>
+    let expected = r##"<p>these are math texts: foo<span class="math inline">y=x</span>bar and <span class="math inline">y=x</span>bar and foo<span class="math inline">y=x</span> bar</p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -137,11 +139,61 @@ backticks doesn't have the edge case: !<span class="math inline">x=y</span>! and
 
 #[test]
 fn math_test_11() {
-    let original = r##"$x=y$
-$`x=y`$
+    let original = r##"$a$$b$
+
+$a$$$b$$
+
+$$a$$$b$
+
+$$a$$$$b$$
 "##;
-    let expected = r##"<p><span class="math inline">x=y</span>
-<span class="math inline">x=y</span></p>
+    let expected = r##"<p><span class="math inline">a</span><span class="math inline">b</span></p>
+<p><span class="math inline">a</span><span class="math display">b</span></p>
+<p><span class="math display">a</span><span class="math inline">b</span></p>
+<p><span class="math display">a</span><span class="math display">b</span></p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn math_test_12() {
+    let original = r##"$Inline `first$ then` code
+
+`Code $first` then$ inline
+
+$$ Display `first $$ then` code
+
+`Code $$ first` then $$ display
+"##;
+    let expected = r##"<p><span class="math inline">Inline `first</span> then` code</p>
+<p><code>Code $first</code> then$ inline</p>
+<p><span class="math display"> Display `first </span> then` code</p>
+<p><code>Code $$ first</code> then $$ display</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn math_test_13() {
+    let original = r##"$x + y - z$
+
+$x + y
+- z$
+
+$$ x + y
+> z $$
+"##;
+    let expected = r##"<p><span class="math inline">x + y - z</span></p>
+<p>$x + y</p>
+<ul>
+<li>z$</li>
+</ul>
+<p>$$ x + y</p>
+<blockquote>
+<p>z $$</p>
+</blockquote>
 "##;
 
     test_markdown_html(original, expected, false, false, false);

--- a/tests/suite/math.rs
+++ b/tests/suite/math.rs
@@ -33,12 +33,12 @@ $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \
 
 #[test]
 fn math_test_3() {
-    let original = r##"$a<b>c$
+    let original = r##"Oops empty $$ expression.
 
-$$a*b*c$$
+$$$$
 "##;
-    let expected = r##"<p><span class="math inline">a&lt;b&gt;c</span></p>
-<p><span class="math display">a*b*c</span></p>
+    let expected = r##"<p>Oops empty $$ expression.</p>
+<p><span class="math display"></span></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -46,9 +46,21 @@ $$a*b*c$$
 
 #[test]
 fn math_test_4() {
-    let original = r##"Oops empty $$ expression.
+    let original = r##"$a<b>c</b>$
+
+$${a*b*c} _c_ d$$
+
+$not `code`$
+
+$![not an](/image)$
+
+$<https://not.a.link/>$
 "##;
-    let expected = r##"<p>Oops empty $$ expression.</p>
+    let expected = r##"<p><span class="math inline">a&lt;b&gt;c&lt;/b&gt;</span></p>
+<p><span class="math display">{a*b*c} _c_ d</span></p>
+<p><span class="math inline">not `code`</span></p>
+<p><span class="math inline">![not an](/image)</span></p>
+<p><span class="math inline">&lt;https://not.a.link/&gt;</span></p>
 "##;
 
     test_markdown_html(original, expected, false, false, false);
@@ -86,6 +98,20 @@ $$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right)
 
 #[test]
 fn math_test_7() {
+    let original = r##"$not a\
+hard break  
+either$
+"##;
+    let expected = r##"<p><span class="math inline">not a\
+hard break  
+either</span></p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn math_test_8() {
     let original = r##"$\$$
 
 $$y = \$ x$$
@@ -98,7 +124,7 @@ $$y = \$ x$$
 }
 
 #[test]
-fn math_test_8() {
+fn math_test_9() {
     let original = r##"$x $ x$
 
 $$ $ $$
@@ -114,7 +140,7 @@ $$ $$ $$
 }
 
 #[test]
-fn math_test_9() {
+fn math_test_10() {
     let original = r##"these are not math texts: $ y=x$, $y=x $, $
 y=x$ and $y=x
 $
@@ -128,7 +154,7 @@ $</p>
 }
 
 #[test]
-fn math_test_10() {
+fn math_test_11() {
     let original = r##"these are math texts: foo$y=x$bar and $y=x$bar and foo$y=x$ bar
 "##;
     let expected = r##"<p>these are math texts: foo<span class="math inline">y=x</span>bar and <span class="math inline">y=x</span>bar and foo<span class="math inline">y=x</span> bar</p>
@@ -138,7 +164,33 @@ fn math_test_10() {
 }
 
 #[test]
-fn math_test_11() {
+fn math_test_12() {
+    let original = r##"math texts: $x=y$! and $x=y$? and $x=y$: and $x=y$. and $x=y$"
+
+also math texts: !$x=y$! and ?$x=y$? and :$x=y$: and .$x=y$. and "$x=y$"
+
+braces: ($x=y$) [$x=y$] {$x=y$}
+"##;
+    let expected = r##"<p>math texts: <span class="math inline">x=y</span>! and <span class="math inline">x=y</span>? and <span class="math inline">x=y</span>: and <span class="math inline">x=y</span>. and <span class="math inline">x=y</span>&quot;</p>
+<p>also math texts: !<span class="math inline">x=y</span>! and ?<span class="math inline">x=y</span>? and :<span class="math inline">x=y</span>: and .<span class="math inline">x=y</span>. and &quot;<span class="math inline">x=y</span>&quot;</p>
+<p>braces: (<span class="math inline">x=y</span>) [<span class="math inline">x=y</span>] {<span class="math inline">x=y</span>}</p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn math_test_13() {
+    let original = r##"$x=y$
+"##;
+    let expected = r##"<p><span class="math inline">x=y</span></p>
+"##;
+
+    test_markdown_html(original, expected, false, false, false);
+}
+
+#[test]
+fn math_test_14() {
     let original = r##"$a$$b$
 
 $a$$$b$$
@@ -157,7 +209,7 @@ $$a$$$$b$$
 }
 
 #[test]
-fn math_test_12() {
+fn math_test_15() {
     let original = r##"$Inline `first$ then` code
 
 `Code $first` then$ inline
@@ -176,7 +228,7 @@ $$ Display `first $$ then` code
 }
 
 #[test]
-fn math_test_13() {
+fn math_test_16() {
     let original = r##"$x + y - z$
 
 $x + y


### PR DESCRIPTION
The syntax implemented here is based on pandoc's `commonmark+math` mode, i.e. <https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/math.md>, excluding the handling for balanced curly braces ~~and how inline math can end in a newline (may be a bug?)~~ (fixed now). The pandoc implementation can be played with in [Try pandoc!](https://pandoc.org/try/) by choosing `commonmark_x` as the input syntax, and `KaTeX` as the math rendering mode.

The idea is that both inline mode and display mode math are inline elements, similar to code spans. This essentially unifies parsing between both modes.

I chose not to support the backtick syntax ```$``$``` for a couple reasons (though it could be added):
- It's not really necessary. The GitHub guide says
  > The latter syntax is useful when the expression you are writing contains characters that overlap with markdown syntax.

  so I believe it was added to circumvent some issues with their (early) implementation. Here, since math has the same precedence as code spans, there should be no such issues.
- The only symbol which can't be put in an inline math item without backticks is an unescaped `$`. In essentially all cases those can be replaced with the LaTeX `\(` and `\)` sequences.
- Robustness. I don't think it's enough to add special cases for `` $` `` etc, because GitHub also supports having more backticks than one:

  ``` $``x``$ ``` is shown as $``x``$

  In the same vein, the earlier implementation on this branch (1ae5351) had quadratic time complexity on an input like `` $` $` $` ... ``.

  For a proper robust implementation, I think after `MaybeMath`, we should try to parse a code span using the exact same logic as is used for normal code spans.
- "Good enough" support can be added by the library user. With the open/close rules implemented here, all ``$`...`$`` are recognized as inline math. All the user needs to do to support the syntax is remove the `` ` `` prefix and suffix from the `Event::Math`.

I also changed to a simpler set of opening/closing rules for inline math, based on what pandoc and commonmark-hs do. It boils down to this:

> In inline math, the opening `$` must not be followed by a whitespace, and the closing `$` must not be preceeded by whitespace.

We could also go with the slightly more refined rules that pandoc's own Markdown flavor changed to recently:

> In inline math, the opening `$` must not be followed by a whitespace, and the closing `$` must not be preceeded by whitespace. The closing `$` must have a non-space character immediately to its left, and must not be followed immediately by a digit.

Using something closer to GitHub's current rules is also an option, but they are a moving target, and don't seem especially consistent or well justified at the moment.